### PR TITLE
Fix template downloading

### DIFF
--- a/gitignore.fish
+++ b/gitignore.fish
@@ -67,7 +67,7 @@ function gitignore -d "Create .gitignore easily using gitignore.io"
     set templates (printf ',%s' $templates | cut -c2-)
 
     if not __gitignore_run "Fetch template" "
-        curl --max-time 10 -sS '$gitignoreio_url/$templates' | tr ',' '\n' > $output
+        curl --max-time 10 -sS '$gitignoreio_url/$templates' > $output
         "
         echo "gitignore: can not fetch template from gitignore.io." > /dev/stderr
         return 1


### PR DESCRIPTION
I couldn't really understand why this `tr` is being done here but some templates do have commas in the middle of patterns (such as [python](https://www.gitignore.io/api/python) and its `*,cover`) which were being incorrectly transformed to newlines.

This specific case with python is interesting because it makes the gitignore ignore ANYTHING as it puts `*` alone in the line.
