### PR TITLE
Fix bug when gitignore contains a comma

### DIFF
--- a/gitignore.fish
+++ b/gitignore.fish
@@ -67,7 +67,7 @@ function gitignore -d "Create .gitignore easily using gitignore.io"
     set templates (printf ',%s' $templates | cut -c2-)
 
     if not __gitignore_run "Fetch template" "
-        curl --max-time 10 -sS '$gitignoreio_url/$templates' | tr ',' '\n' > $output
+        curl --max-time 10 -sS '$gitignoreio_url/$templates' > $output
         "
         echo "gitignore: can not fetch template from gitignore.io." > /dev/stderr
         return 1


### PR DESCRIPTION
With the script translate all `,` to `\n` it will generate a invalid `.gitignore` file.
For example, the file https://www.gitignore.io/api/python contains the lines:

```
#  before PyInstaller builds the exe, so as to inject date/other infos into it.

*,cover
```

And will be translated to:

```
#  before PyInstaller builds the exe
 so as to inject date/other infos into it.

*
cover
```
