### PR TITLE
Replace gitignore.io with toptal.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gitignore
 
-Create `.gitignore` files from [gitignore.io](https://www.gitignore.io) templates.
+Create `.gitignore` files from [gitignore.io](https://www.toptal.com/developers/gitignore) templates.
 
 ## Install
 

--- a/gitignore.fish
+++ b/gitignore.fish
@@ -11,7 +11,7 @@ function gitignore -d "Create .gitignore easily using gitignore.io"
     set -l templates
     set -l update 0
     set -l cache_home $XDG_CACHE_HOME
-    set -l gitignoreio_url "https://www.gitignore.io/api/"
+    set -l gitignoreio_url "https://www.toptal.com/developers/gitignore/api/"
 
     if test -z "$cache_home"
         set cache_home ~/.cache


### PR DESCRIPTION
Hi!

The gitignore.io website had moved, so I changed API url with the new one.

Regards.

---

gitignore.ioのウェブサイトが移転していたので修正しました。
よろしくおねがいします。