### PR TITLE
Rename fishfile to fish_plugins

### DIFF
--- a/fish_plugins
+++ b/fish_plugins
@@ -1,0 +1,1 @@
+americanhanko/fish-spin

--- a/fishfile
+++ b/fishfile
@@ -1,1 +1,0 @@
-fishpkg/fish-spin


### PR DESCRIPTION
See: https://github.com/jorgebucaran/fisher/issues/524
And, "fishpkg/fish-spin" is now removed.
it seems that "americanhanko/fish-spin" can be used as a substitute.